### PR TITLE
Remove dynamic dispatch

### DIFF
--- a/.github/workflows/pull-request-build.yml
+++ b/.github/workflows/pull-request-build.yml
@@ -15,3 +15,6 @@ jobs:
         with:
           command: build
           args: --release --all-features
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test

--- a/.github/workflows/pull-request-build.yml
+++ b/.github/workflows/pull-request-build.yml
@@ -1,0 +1,17 @@
+on: [push]
+
+name: Pull Request Build and Test
+
+jobs:
+  build_and_test:
+    name: Rust project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --all-features

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -5,3 +5,4 @@ pub mod deprecated_attribute;
 pub mod exception_attribute;
 pub mod signature_attribute;
 pub mod attribute_factory;
+pub mod attribute_container;

--- a/src/attributes/attribute_container.rs
+++ b/src/attributes/attribute_container.rs
@@ -1,0 +1,22 @@
+use crate::attributes::attribute_info::AttributeInfo;
+use serde::{Serialize, Serializer, Deserialize, Deserializer};
+use crate::constants::constant_info::ConstantInfo;
+use crate::constants::utf8_info::Utf8Info;
+use crate::attributes::code_attribute::CodeAttribute;
+use crate::attributes::constant_value_attribute::ConstantValueAttribute;
+use crate::attributes::deprecated_attribute::DeprecatedAttribute;
+use crate::attributes::signature_attribute::SignatureAttribute;
+use crate::attributes::exception_attribute::ExceptionAttribute;
+use std::any::Any;
+use serde::de::Error;
+
+#[derive(PartialEq, Eq, Serialize, Deserialize, Debug, Clone)]
+pub enum AttributeContainer
+{
+    CodeAttribute(CodeAttribute),
+    ConstantAttribute(ConstantValueAttribute),
+    DeprecatedAttribute(DeprecatedAttribute),
+    SignatureAttribute(SignatureAttribute),
+    ExceptionAttribute(ExceptionAttribute),
+}
+

--- a/src/attributes/attribute_container.rs
+++ b/src/attributes/attribute_container.rs
@@ -20,3 +20,27 @@ pub enum AttributeContainer
     ExceptionAttribute(ExceptionAttribute),
 }
 
+impl AttributeInfo for AttributeContainer
+{
+    fn name_index(&self) -> &u16 {
+        match self
+        {
+            AttributeContainer::CodeAttribute(v) => v.name_index(),
+            AttributeContainer::ConstantAttribute(v) => v.name_index(),
+            AttributeContainer::DeprecatedAttribute(v) => v.name_index(),
+            AttributeContainer::SignatureAttribute(v) => v.name_index(),
+            AttributeContainer::ExceptionAttribute(v) => v.name_index()
+        }
+    }
+
+    fn attr_length(&self) -> &u32 {
+        match self
+        {
+            AttributeContainer::CodeAttribute(v) => v.attr_length(),
+            AttributeContainer::ConstantAttribute(v) => v.attr_length(),
+            AttributeContainer::DeprecatedAttribute(v) => v.attr_length(),
+            AttributeContainer::SignatureAttribute(v) => v.attr_length(),
+            AttributeContainer::ExceptionAttribute(v) => v.attr_length()
+        }
+    }
+}

--- a/src/attributes/attribute_factory.rs
+++ b/src/attributes/attribute_factory.rs
@@ -7,6 +7,8 @@ use crate::attributes::constant_value_attribute::ConstantValueAttribute;
 use crate::attributes::deprecated_attribute::DeprecatedAttribute;
 use crate::attributes::signature_attribute::SignatureAttribute;
 use crate::attributes::exception_attribute::ExceptionAttribute;
+use crate::attributes::attribute_container::AttributeContainer;
+use crate::constants::constant_container::ConstantContainer;
 
 const CONSTANT_VALUE: &str = "ConstantValue";
 const CODE: &str = "Code";
@@ -14,23 +16,23 @@ const DEPRECATED: &str = "Deprecated";
 const SIGNATURE: &str = "Signature";
 const EXCEPTION: &str = "Exception";
 
-pub fn get_attribute<T: ReadBytes>(mut data: &mut T, constant_pool: &[Box<dyn ConstantInfo>]) -> Box<dyn AttributeInfo>
+pub fn get_attribute_container<T: ReadBytes>(mut data: &mut T, constant_pool: &[ConstantContainer]) -> AttributeContainer
 {
     let mut attr_index = data.peek_u16();
     let constant_info = &constant_pool[attr_index as usize];
-    let utf8_info: &Utf8Info = match constant_info.as_any().downcast_ref::<Utf8Info>() {
-        Some(info) => info,
-        None => panic!("The index into the constant pool isn't a utf8 into constant info"),
+    let attribute_type: &str = match constant_info
+    {
+        ConstantContainer::Utf8Info( v ) => v.get_string(),
+        _ => panic!("Expected enum value of utf8info.")
     };
 
-    let attribute_type = utf8_info.get_string();
     match attribute_type
     {
-        CONSTANT_VALUE =>   { Box::new(ConstantValueAttribute::new(data)) },
-        CODE =>             { Box::new(CodeAttribute::new(data, &constant_pool)) },
-        DEPRECATED =>       { Box::new(DeprecatedAttribute::new(data)) },
-        SIGNATURE =>        { Box::new(SignatureAttribute::new(data)) },
-        EXCEPTION =>        { Box::new(ExceptionAttribute::new(data)) },
+        CODE =>             { AttributeContainer::CodeAttribute(CodeAttribute::new(data, &constant_pool)) },
+        CONSTANT_VALUE =>   { AttributeContainer::ConstantAttribute(ConstantValueAttribute::new(data)) },
+        DEPRECATED =>       { AttributeContainer::DeprecatedAttribute(DeprecatedAttribute::new(data)) },
+        SIGNATURE =>        { AttributeContainer::SignatureAttribute(SignatureAttribute::new(data)) },
+        EXCEPTION =>        { AttributeContainer::ExceptionAttribute(ExceptionAttribute::new(data)) }
         &_ => panic!("Unidentified attribute")
     }
 }

--- a/src/attributes/attribute_info.rs
+++ b/src/attributes/attribute_info.rs
@@ -4,18 +4,10 @@
 /// Implemented: 2,3,5,8,9,
 /// Annotations: 15,16,17,18,19,20
 ///
-use std::any::Any;
-use crate::attributes::constant_value_attribute::ConstantValueAttribute;
-use crate::attributes::code_attribute::CodeAttribute;
-use crate::attributes::deprecated_attribute::DeprecatedAttribute;
-use crate::attributes::exception_attribute::ExceptionAttribute;
-use crate::attributes::signature_attribute::SignatureAttribute;
-
 pub trait AttributeInfo
 {
     fn name_index(&self) -> &u16;
     fn attr_length(&self) -> &u32;
-    fn as_any(&self) -> &dyn Any;
 }
 
 /*

--- a/src/attributes/code_attribute.rs
+++ b/src/attributes/code_attribute.rs
@@ -1,10 +1,12 @@
 use crate::attributes::attribute_info::AttributeInfo;
 use crate::read_bytes::ReadBytes;
-use std::any::Any;
 use crate::constants::constant_info::ConstantInfo;
-use crate::attributes::attribute_factory::get_attribute;
+use crate::attributes::attribute_factory::{get_attribute_container};
+use serde::ser::{Serialize, Serializer, SerializeStruct};
+use crate::attributes::attribute_container::AttributeContainer;
+use crate::constants::constant_container::ConstantContainer;
 
-#[derive(Default)]
+#[derive(Default, PartialEq, Eq, Serialize, Deserialize, Debug, Clone)]
 pub struct CodeAttribute
 {
     attribute_name_index: u16,
@@ -16,19 +18,18 @@ pub struct CodeAttribute
     exception_table_length: u16,
     exception_table: Vec<ExceptionInfo>,
     attribute_count: u16,
-    attribute_info: Vec<Box<dyn AttributeInfo>>
+    attribute_info: Vec<AttributeContainer>
 }
 
 impl AttributeInfo for CodeAttribute
 {
     fn name_index(&self) -> &u16 { &self.attribute_name_index }
     fn attr_length(&self) -> &u32 { &self.attribute_length }
-    fn as_any(&self) -> &dyn Any { self }
 }
 
 impl CodeAttribute
 {
-    pub fn new<T: ReadBytes>(mut data: &mut T, constant_pool: &[Box<dyn ConstantInfo>]) -> CodeAttribute
+    pub fn new<T: ReadBytes>(mut data: &mut T, constant_pool: &[ConstantContainer]) -> CodeAttribute
     {
         let mut result: CodeAttribute = Default::default();
         result.attribute_name_index = data.pop_u16();
@@ -49,12 +50,14 @@ impl CodeAttribute
         result.attribute_info = Vec::new();
         for _i in 0..result.attribute_length.clone()
         {
-            result.attribute_info.push(get_attribute(data, &constant_pool));
+            result.attribute_info.push(get_attribute_container(data, &constant_pool));
         }
 
         result
     }
 }
+
+
 
 #[derive(Default, PartialEq, Eq, Serialize, Deserialize, Debug, Clone)]
 pub struct ExceptionInfo

--- a/src/attributes/code_attribute.rs
+++ b/src/attributes/code_attribute.rs
@@ -35,6 +35,7 @@ impl CodeAttribute
         result.attribute_name_index = data.pop_u16();
         result.attribute_length = data.pop_u32();
         result.max_stack = data.pop_u16();
+        result.max_locals = data.pop_u16();
         result.code_length = data.pop_u32();
         result.code = data.pop_vec(result.code_length.clone() as usize);
         result.exception_table_length = data.pop_u16();
@@ -48,7 +49,7 @@ impl CodeAttribute
 
         result.attribute_count = data.pop_u16();
         result.attribute_info = Vec::new();
-        for _i in 0..result.attribute_length.clone()
+        for _i in 0..result.attribute_count.clone()
         {
             result.attribute_info.push(get_attribute_container(data, &constant_pool));
         }
@@ -82,66 +83,173 @@ impl ExceptionInfo
     }
 }
 
-// #[cfg(test)]
-// mod tests
-// {
-//     use serde_json::Result;
-//     use crate::attributes::code_attribute::ExceptionInfo;
-//
-//     #[test]
-//     fn exception_info_implements_equality_by_default()
-//     {
-//         let instance1: ExceptionInfo = Default::default();
-//         let instance2: ExceptionInfo = Default::default();
-//
-//         assert_eq!(instance1, instance2);
-//     }
-//
-//     #[test]
-//     fn exception_info_constructs_expected_struct()
-//     {
-//         let data: Vec<u8> = vec![1, 1, 1, 1, 1, 1, 1, 1];
-//         let result: ExceptionInfo = ExceptionInfo::new(&data);
-//
-//         let bit16: u16 = 257;
-//         assert_eq!(bit16, result.start_pc);
-//         assert_eq!(bit16, result.end_pc);
-//         assert_eq!(bit16, result.handler_pc);
-//         assert_eq!(bit16, result.catch_type);
-//     }
-//
-//     #[test]
-//     fn exception_info_implements_equality_correctly()
-//     {
-//         let data: Vec<u8> = vec![1, 2, 3, 4, 5, 6, 7, 8];
-//         let instance1: ExceptionInfo = ExceptionInfo::new(&data);
-//         let instance2: ExceptionInfo = ExceptionInfo::new(&data);
-//
-//         assert_eq!(instance1, instance2);
-//     }
-//
-//     #[test]
-//     fn exception_info_implements_equality_correctly_when_not_equal()
-//     {
-//         let data1: Vec<u8> = vec![1, 2, 3, 4, 5, 6, 7, 8];
-//         let data2: Vec<u8> = vec![8, 7, 6, 5, 4, 3, 2, 1];
-//         let instance1: ExceptionInfo = ExceptionInfo::new(&data1);
-//         let instance2: ExceptionInfo = ExceptionInfo::new(&data2);
-//
-//         assert_ne!(instance1, instance2);
-//     }
-//
-//     #[test]
-//     fn exception_info_implements_json_serialization_correctly() -> Result<()>
-//     {
-//         let data: Vec<u8> = vec![1, 2, 3, 4, 5, 6, 7, 8];
-//         let instance1: ExceptionInfo = ExceptionInfo::new(&data);
-//         let instance2 = instance1.clone();
-//
-//         let json = serde_json::to_string_pretty(&instance1)?;
-//         let instance3: ExceptionInfo = serde_json::from_str(&json)?;
-//
-//         assert_eq!(instance2, instance3);
-//         Ok(())
-//     }
-// }
+#[cfg(test)]
+mod tests
+{
+    use crate::attributes::code_attribute::{ExceptionInfo, CodeAttribute};
+    use serde_json::Result;
+    use std::collections::VecDeque;
+    use crate::vecdeque;
+    use crate::attributes::attribute_container::AttributeContainer;
+    use crate::attributes::constant_value_attribute::ConstantValueAttribute;
+    use crate::constants::constant_container::ConstantContainer;
+    use crate::constants::class_info::ClassInfo;
+
+    #[test]
+    fn exception_info_implements_equality_by_default()
+    {
+        let instance1: ExceptionInfo = Default::default();
+        let instance2: ExceptionInfo = Default::default();
+
+        assert_eq!(instance1, instance2);
+    }
+
+    #[test]
+    fn exception_info_constructs_expected_struct()
+    {
+        let mut data: VecDeque<u8> = vecdeque![1, 1, 1, 1, 1, 1, 1, 1];
+        let result: ExceptionInfo = ExceptionInfo::new(&mut data);
+
+        let bit16: u16 = 257;
+        assert_eq!(bit16, result.start_pc);
+        assert_eq!(bit16, result.end_pc);
+        assert_eq!(bit16, result.handler_pc);
+        assert_eq!(bit16, result.catch_type);
+    }
+
+    #[test]
+    fn exception_info_implements_equality_correctly()
+    {
+        let mut data: VecDeque<u8> = vecdeque![1, 2, 3, 4, 5, 6, 7, 8];
+        let mut data2: VecDeque<u8> = data.clone();
+        let instance1: ExceptionInfo = ExceptionInfo::new(&mut data);
+        let instance2: ExceptionInfo = ExceptionInfo::new(&mut data2);
+
+        assert_eq!(instance1, instance2);
+    }
+
+    #[test]
+    fn exception_info_implements_equality_correctly_when_not_equal()
+    {
+        let mut data1: VecDeque<u8> = vecdeque![1, 2, 3, 4, 5, 6, 7, 8];
+        let mut data2: VecDeque<u8> = vecdeque![8, 7, 6, 5, 4, 3, 2, 1];
+        let instance1: ExceptionInfo = ExceptionInfo::new(&mut data1);
+        let instance2: ExceptionInfo = ExceptionInfo::new(&mut data2);
+
+        assert_ne!(instance1, instance2);
+    }
+
+    #[test]
+    fn exception_info_implements_json_serialization_correctly() -> Result<()>
+    {
+        let mut data: VecDeque<u8> = vecdeque![1, 2, 3, 4, 5, 6, 7, 8];
+        let instance1: ExceptionInfo = ExceptionInfo::new(&mut data);
+        let instance2 = instance1.clone();
+
+        let json = serde_json::to_string_pretty(&instance1)?;
+        let instance3: ExceptionInfo = serde_json::from_str(&json)?;
+
+        assert_eq!(instance2, instance3);
+        Ok(())
+    }
+
+    #[test]
+    fn code_attribute_implements_equality_by_default()
+    {
+        let instance1: CodeAttribute = Default::default();
+        let instance2: CodeAttribute = Default::default();
+
+        assert_eq!(instance1, instance2);
+    }
+
+    #[test]
+    fn code_attribute_constructs_expected_struct()
+    {
+        let mut data: VecDeque<u8> = get_default_code_attribute_vec();
+        let constant_pool: Vec<ConstantContainer> = get_default_constant_container();
+        let result: CodeAttribute = CodeAttribute::new(&mut data, constant_pool.as_slice());
+
+        assert_eq!(258, result.attribute_name_index);
+        assert_eq!(131077, result.attribute_length);
+        assert_eq!(1029, result.max_stack);
+        assert_eq!(1537, result.max_locals);
+        assert_eq!(4, result.code_length);
+
+        let expected_code: Vec<u8> = vec![1, 2, 3, 4];
+        assert_eq!(expected_code, result.code);
+
+        assert_eq!(1, result.exception_table_length);
+
+        let mut expected_exception_vec = vecdeque![1, 1, 1, 2, 2, 5, 3, 4];
+        let expected_exception = ExceptionInfo::new(&mut expected_exception_vec);
+        assert_eq!(1, result.exception_table.len());
+        assert_eq!(expected_exception, result.exception_table[0]);
+
+        assert_eq!(0, result.attribute_count);
+        assert_eq!(0, result.attribute_info.len());
+    }
+
+    fn code_attribute_implements_equality_correctly()
+    {
+        let mut data: VecDeque<u8> = get_default_code_attribute_vec();
+        let mut data2: VecDeque<u8> = data.clone();
+        let constant_pool = get_default_constant_container();
+        let instance1: CodeAttribute = CodeAttribute::new(&mut data, &constant_pool);
+        let instance2: CodeAttribute = CodeAttribute::new(&mut data2, &constant_pool);
+
+        assert_eq!(instance1, instance2);
+    }
+
+    #[test]
+    fn code_attribute_implements_equality_correctly_when_not_equal()
+    {
+        let mut data1: VecDeque<u8> = get_default_code_attribute_vec();
+        let mut data2: VecDeque<u8> = get_default_code_attribute_vec();
+        data2[0] = data1[0] + 1;
+        let constant_pool = get_default_constant_container();
+        let instance1: CodeAttribute = CodeAttribute::new(&mut data1, &constant_pool);
+        let instance2: CodeAttribute = CodeAttribute::new(&mut data2, &constant_pool);
+
+        assert_ne!(instance1, instance2);
+    }
+
+    #[test]
+    fn code_attribute_implements_json_serialization_correctly() -> Result<()>
+    {
+        let mut data: VecDeque<u8> = get_default_code_attribute_vec();
+        let constant_pool = get_default_constant_container();
+
+        let instance1: CodeAttribute = CodeAttribute::new(&mut data, &constant_pool);
+        let instance2 = instance1.clone();
+
+        let json = serde_json::to_string_pretty(&instance1)?;
+        let instance3: CodeAttribute = serde_json::from_str(&json)?;
+
+        assert_eq!(instance2, instance3);
+        Ok(())
+    }
+
+    fn get_default_code_attribute_vec() -> VecDeque<u8>
+    {
+        vecdeque![
+            1, 2,       // attribute_name_index = 258
+            0, 2, 0, 5, // attribute_length = 131077
+            4, 5,       // max_stack = 1029
+            6, 1,       // max_locals = 1537
+            0, 0, 0, 4, // code_length = 4
+            1, 2, 3, 4, // code = 1, 2, 3, 4
+            0, 1,       // exception table length = 1
+                1, 1,   // ExceptionInfo::start_pc = 257
+                1, 2,   // ExceptionInfo::end_pc = 258
+                2, 5,   // ExceptionInfo::handler_pc = 517
+                3, 4,   // ExceptionInfo::catch_type = 772
+            0, 0        // attribute_count = 0
+        ]
+    }
+
+    fn get_default_constant_container() -> Vec<ConstantContainer>
+    {
+        let const_info: ClassInfo = Default::default();
+        vec![ConstantContainer::ClassInfo(const_info)]
+    }
+}

--- a/src/attributes/constant_value_attribute.rs
+++ b/src/attributes/constant_value_attribute.rs
@@ -1,6 +1,5 @@
 use crate::attributes::attribute_info::AttributeInfo;
 use crate::read_bytes::ReadBytes;
-use std::any::Any;
 
 #[derive(Default, PartialEq, Eq, Serialize, Deserialize, Debug, Clone)]
 pub struct ConstantValueAttribute
@@ -14,7 +13,6 @@ impl AttributeInfo for ConstantValueAttribute
 {
     fn name_index(&self) -> &u16 { &self.attribute_name_index }
     fn attr_length(&self) -> &u32 { &self.attribute_length }
-    fn as_any(&self) -> &dyn Any { self }
 }
 
 impl ConstantValueAttribute

--- a/src/attributes/deprecated_attribute.rs
+++ b/src/attributes/deprecated_attribute.rs
@@ -1,6 +1,5 @@
 use crate::attributes::attribute_info::AttributeInfo;
 use crate::read_bytes::ReadBytes;
-use std::any::Any;
 
 #[derive(Default, PartialEq, Eq, Serialize, Deserialize, Debug, Clone)]
 pub struct DeprecatedAttribute
@@ -13,7 +12,6 @@ impl AttributeInfo for DeprecatedAttribute
 {
     fn name_index(&self) -> &u16 { &self.attribute_name_index }
     fn attr_length(&self) -> &u32 { &self.attribute_length }
-    fn as_any(&self) -> &dyn Any { self }
 }
 
 impl DeprecatedAttribute

--- a/src/attributes/exception_attribute.rs
+++ b/src/attributes/exception_attribute.rs
@@ -1,6 +1,5 @@
 use crate::read_bytes::ReadBytes;
 use crate::attributes::attribute_info::AttributeInfo;
-use std::any::Any;
 use core::mem::size_of;
 
 #[derive(Default, PartialEq, Eq, Serialize, Deserialize, Debug, Clone)]
@@ -16,7 +15,6 @@ impl AttributeInfo for ExceptionAttribute
 {
     fn name_index(&self) -> &u16 { &self.attribute_name_index }
     fn attr_length(&self) -> &u32 { &self.attribute_length }
-    fn as_any(&self) -> &dyn Any { self }
 }
 
 impl ExceptionAttribute

--- a/src/attributes/signature_attribute.rs
+++ b/src/attributes/signature_attribute.rs
@@ -1,6 +1,5 @@
 use crate::attributes::attribute_info::AttributeInfo;
 use crate::read_bytes::ReadBytes;
-use std::any::Any;
 use core::mem::size_of;
 
 #[derive(Default, PartialEq, Eq, Serialize, Deserialize, Debug, Clone)]
@@ -15,7 +14,6 @@ impl AttributeInfo for SignatureAttribute
 {
     fn name_index(&self) -> &u16 { &self.attribute_name_index }
     fn attr_length(&self) -> &u32 { &self.attribute_length }
-    fn as_any(&self) -> &dyn Any { self }
 }
 
 impl SignatureAttribute

--- a/src/class_struct.rs
+++ b/src/class_struct.rs
@@ -1,18 +1,19 @@
-use crate::attributes::attribute_info::AttributeInfo;
 use crate::constants::constant_info::ConstantInfo;
 use crate::field_info::FieldInfo;
 use crate::method_info::MethodInfo;
 use crate::read_bytes::ReadBytes;
-use crate::constants::constant_factory::get_constant;
-use crate::attributes::attribute_factory::get_attribute;
+use crate::constants::constant_factory::{get_constant_container};
+use crate::attributes::attribute_factory::get_attribute_container;
+use crate::attributes::attribute_container::AttributeContainer;
+use crate::constants::constant_container::ConstantContainer;
 
-#[derive(Default)]
+#[derive(Default, PartialEq, Eq, Serialize, Deserialize, Debug, Clone)]
 struct ClassStruct {
     magic: u32,
     minor_version: u16,
     major_version: u16,
     constant_pool_count: u16,
-    constant_pool: Vec<Box<dyn ConstantInfo>>,
+    constant_pool: Vec<ConstantContainer>,
     access_flags: u16,
     this_class: u16,
     super_class: u16,
@@ -23,7 +24,7 @@ struct ClassStruct {
     methods_count: u16,
     method_info: Vec<MethodInfo>,
     attributes_count: u16,
-    attribute_info: Vec<Box<dyn AttributeInfo>>
+    attribute_info: Vec<AttributeContainer>
 }
 
 impl ClassStruct
@@ -38,7 +39,7 @@ impl ClassStruct
         result.constant_pool = Vec::new();
         for _i in 0..result.constant_pool_count.clone()
         {
-            result.constant_pool.push(get_constant(data));
+            result.constant_pool.push(get_constant_container(data));
         }
 
         result.access_flags = data.pop_u16();
@@ -69,7 +70,7 @@ impl ClassStruct
         result.attribute_info = Vec::new();
         for _i in 0..result.attributes_count.clone()
         {
-            result.attribute_info.push(get_attribute(data, &result.constant_pool));
+            result.attribute_info.push(get_attribute_container(data, &result.constant_pool));
         }
 
         result

--- a/src/class_struct.rs
+++ b/src/class_struct.rs
@@ -76,3 +76,172 @@ impl ClassStruct
         result
     }
 }
+
+
+#[cfg(test)]
+mod tests
+{
+    use serde_json::Result;
+    use crate::vecdeque;
+    use std::collections::VecDeque;
+    use crate::constants::constant_container::ConstantContainer;
+    use crate::constants::utf8_info::Utf8Info;
+    use crate::attributes::constant_value_attribute::ConstantValueAttribute;
+    use crate::attributes::attribute_container::AttributeContainer;
+    use crate::class_struct::ClassStruct;
+    use crate::field_info::FieldInfo;
+    use crate::method_info::MethodInfo;
+    use crate::constants::constant_container::ConstantContainer::ClassInfo;
+
+    #[test]
+    fn class_struct_implements_equality_by_default()
+    {
+        let instance1: ClassStruct = Default::default();
+        let instance2: ClassStruct = Default::default();
+
+        assert_eq!(instance1, instance2);
+    }
+
+    #[test]
+    fn class_struct_constructs_expected_struct()
+    {
+        let mut data: VecDeque<u8> = get_default_vec();
+        let result: ClassStruct = ClassStruct::new(&mut data);
+
+        assert_eq!(0xCAFEBABE, result.magic);
+        assert_eq!(256, result.minor_version);
+        assert_eq!(1, result.major_version);
+        assert_eq!(1, result.constant_pool_count);
+        assert_eq!(1, result.constant_pool.len());
+
+        let mut constant_pool_vec = vecdeque![
+            1,
+            0, 13,
+            'C' as u8, 'o' as u8, 'n' as u8, 's' as u8,
+            't' as u8, 'a' as u8, 'n' as u8, 't' as u8,
+            'V' as u8, 'a' as u8, 'l' as u8, 'u' as u8,
+            'e' as u8];
+        let expected_constant = ConstantContainer::Utf8Info(Utf8Info::new(&mut constant_pool_vec));
+        assert_eq!(expected_constant, result.constant_pool[0]);
+        assert_eq!(1, result.access_flags);
+        assert_eq!(1, result.this_class);
+        assert_eq!(2, result.super_class);
+        assert_eq!(2, result.interfaces_count);
+        assert_eq!(2, result.interfaces.len());
+
+        let expected_interfaces = vec![2, 4];
+        assert_eq!(expected_interfaces, result.interfaces);
+
+        assert_eq!(1, result.fields_count);
+        assert_eq!(1, result.field_info.len());
+
+        let mut expected_field_content = vecdeque![
+            0, 1, 0, 0, 0, 0, 0, 1,
+            0, 0, 2, 2, 0, 0, 1, 1
+        ];
+        let expected_field = FieldInfo::new(&mut expected_field_content, &result.constant_pool);
+        assert_eq!(expected_field, result.field_info[0]);
+
+        assert_eq!(1, result.methods_count);
+        assert_eq!(1, result.method_info.len());
+
+        let mut expected_method_content = vecdeque![
+            0, 1, 0, 0, 0, 0, 0, 1,
+            0, 0, 2, 2, 0, 0, 1, 1
+        ];
+        let expected_method = MethodInfo::new(&mut expected_method_content, &result.constant_pool);
+        assert_eq!(expected_method, result.method_info[0]);
+
+        assert_eq!(1, result.attributes_count);
+        assert_eq!(1, result.attribute_info.len());
+
+        let mut expected_attribute_content = vecdeque![
+            0, 0, 2, 2, 0, 0, 1, 1
+        ];
+        let expected_attribute = AttributeContainer::ConstantAttribute(ConstantValueAttribute::new(&mut expected_attribute_content));
+        assert_eq!(expected_attribute, result.attribute_info[0]);
+    }
+
+    #[test]
+    fn class_struct_implements_equality_correctly()
+    {
+        let mut data: VecDeque<u8> = get_default_vec();
+        let mut data2: VecDeque<u8> = data.clone();
+
+        let result: ClassStruct = ClassStruct::new(&mut data);
+        let result2: ClassStruct = ClassStruct::new(&mut data2);
+        assert_eq!(result, result2);
+    }
+
+    #[test]
+    fn class_struct_implements_equality_correctly_when_not_equal()
+    {
+        let mut data: VecDeque<u8> = get_default_vec();
+        let mut data2: VecDeque<u8> = data.clone();
+        data2[0] = data[0] + 1;
+
+        let result: ClassStruct = ClassStruct::new(&mut data);
+        let result2: ClassStruct = ClassStruct::new(&mut data2);
+        assert_ne!(result, result2);
+    }
+
+    #[test]
+    fn class_struct_implements_json_serialization_correctly() -> Result<()>
+    {
+        let mut data: VecDeque<u8> = get_default_vec();
+
+        let instance1: ClassStruct = ClassStruct::new(&mut data);
+        let instance2 = instance1.clone();
+
+        let json = serde_json::to_string_pretty(&instance1)?;
+        let instance3: ClassStruct = serde_json::from_str(&json)?;
+
+        assert_eq!(instance2, instance3);
+        Ok(())
+    }
+
+    fn get_default_vec() -> VecDeque<u8>
+    {
+        vecdeque![
+            202, 254, 186, 190, // magic: u32: 3405691582
+            1, 0,       // minor_version: u16: 256
+            0, 1,       // major_version: u16: 1
+            0, 1,       // constant_pool_count: u16: 1
+            1,          //      Utf8Info::tag: 1
+            0, 13,      //      Utf8Info::length: 13
+            'C' as u8, 'o' as u8, 'n' as u8, 's' as u8,
+            't' as u8, 'a' as u8, 'n' as u8, 't' as u8,
+            'V' as u8, 'a' as u8, 'l' as u8, 'u' as u8,
+            'e' as u8,  //      Utf8Info::value: "ConstantValue"
+                        // constant_pool: Vec<ConstantContainer>,
+            0, 1,       // access_flags: u16: 1
+            0, 1,       // this_class: u16: 1
+            0, 2,       // super_class: u16: 2
+            0, 2,       // interfaces_count: u16: 4
+            0, 2, 0, 4, // interfaces: Vec<u16>: [1,2,3,4]
+            0, 1,       // fields_count: u16: 1
+            0, 1,       //      FieldInfo::access_flags: 1
+            0, 0,       //      FieldInfo::name_index: 0
+            0, 0,       //      FieldInfo::descriptor_index: 0
+            0, 1,       //      FieldInfo::attributes_count: 0
+            0, 0,       //          ConstantValueAttribute::attribute_name_index: 0
+            2, 2, 0, 0, //          ConstantValueAttribute::attribute_length: 8590065664
+            1, 1,       //          ConstantValueAttribute::constant_value_index: 257
+                        // field_info: Vec<FieldInfo>,
+            0, 1,       // methods_count: u16: 1
+            0, 1,       //      MethodInfo::access_flags: 1
+            0, 0,       //      MethodInfo::name_index: 0
+            0, 0,       //      MethodInfo::descriptor_index: 0
+            0, 1,       //      MethodInfo::attributes_count: 1
+            0, 0,       //          ConstantValueAttribute::attribute_name_index: 0
+            2, 2, 0, 0, //          ConstantValueAttribute::attribute_length: 8590065664
+            1, 1,       //          ConstantValueAttribute::constant_value_index: 257
+                        // method_info: Vec<MethodInfo>,
+            0, 1,       // attributes_count: u16: 1
+            0, 0,       //      ConstantValueAttribute::attribute_name_index: 0
+            2, 2, 0, 0, //      ConstantValueAttribute::attribute_length: 8590065664
+            1, 1,       //      ConstantValueAttribute::constant_value_index: 257
+                        // attribute_info: Vec<AttributeContainer>
+        ]
+    }
+}

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -14,3 +14,4 @@ mod double_info;
 mod field_ref_info;
 mod method_ref_info;
 pub mod constant_factory;
+pub mod constant_container;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,5 +1,5 @@
 pub mod constant_info;
-mod class_info;
+pub mod class_info;
 mod interface_method_ref_info;
 mod string_info;
 mod integer_info;

--- a/src/constants/class_info.rs
+++ b/src/constants/class_info.rs
@@ -1,6 +1,5 @@
 use crate::constants::constant_info::ConstantInfo;
 use crate::read_bytes::ReadBytes;
-use std::any::Any;
 
 #[derive(Default, PartialEq, Eq, Serialize, Deserialize, Debug, Clone)]
 pub struct ClassInfo
@@ -12,7 +11,6 @@ pub struct ClassInfo
 impl ConstantInfo for ClassInfo
 {
     fn tag(&self) -> &u8 { &self.tag }
-    fn as_any(&self) -> &dyn Any { self }
 }
 
 impl ClassInfo

--- a/src/constants/constant_container.rs
+++ b/src/constants/constant_container.rs
@@ -12,6 +12,7 @@ use crate::constants::name_and_type_info::NameAndTypeInfo;
 use crate::constants::string_info::StringInfo;
 use crate::constants::utf8_info::Utf8Info;
 use crate::constants::class_info::ClassInfo;
+use crate::constants::constant_info::ConstantInfo;
 
 #[derive(PartialEq, Eq, Serialize, Deserialize, Debug, Clone)]
 pub enum ConstantContainer
@@ -30,4 +31,27 @@ pub enum ConstantContainer
     NameAndTypeInfo(NameAndTypeInfo),
     StringInfo(StringInfo),
     Utf8Info(Utf8Info)
+}
+
+impl ConstantInfo for ConstantContainer
+{
+    fn tag(&self) -> &u8 {
+        match self
+        {
+            ConstantContainer::ClassInfo(v) => v.tag(),
+            ConstantContainer::DoubleInfo(v) => v.tag(),
+            ConstantContainer::FieldRefInfo(v) => v.tag(),
+            ConstantContainer::FloatInfo(v) => v.tag(),
+            ConstantContainer::IntegerInfo(v) => v.tag(),
+            ConstantContainer::InterfaceMethodInfo(v) => v.tag(),
+            ConstantContainer::InvokeDynamicInfo(v) => v.tag(),
+            ConstantContainer::LongInfo(v) => v.tag(),
+            ConstantContainer::MethodHandleInfo(v) => v.tag(),
+            ConstantContainer::MethodRefInfo(v) => v.tag(),
+            ConstantContainer::MethodTypeInfo(v) => v.tag(),
+            ConstantContainer::NameAndTypeInfo(v) => v.tag(),
+            ConstantContainer::StringInfo(v) => v.tag(),
+            ConstantContainer::Utf8Info(v) => v.tag()
+        }
+    }
 }

--- a/src/constants/constant_container.rs
+++ b/src/constants/constant_container.rs
@@ -1,0 +1,33 @@
+use crate::constants::double_info::DoubleInfo;
+use crate::constants::field_ref_info::FieldRefInfo;
+use crate::constants::float_info::FloatInfo;
+use crate::constants::integer_info::IntegerInfo;
+use crate::constants::interface_method_ref_info::InterfaceMethodRefInfo;
+use crate::constants::invoke_dynamic_info::InvokeDynamicInfo;
+use crate::constants::long_info::LongInfo;
+use crate::constants::method_handle_info::MethodHandleInfo;
+use crate::constants::method_ref_info::MethodRefInfo;
+use crate::constants::method_type_info::MethodTypeInfo;
+use crate::constants::name_and_type_info::NameAndTypeInfo;
+use crate::constants::string_info::StringInfo;
+use crate::constants::utf8_info::Utf8Info;
+use crate::constants::class_info::ClassInfo;
+
+#[derive(PartialEq, Eq, Serialize, Deserialize, Debug, Clone)]
+pub enum ConstantContainer
+{
+    ClassInfo(ClassInfo),
+    DoubleInfo(DoubleInfo),
+    FieldRefInfo(FieldRefInfo),
+    FloatInfo(FloatInfo),
+    IntegerInfo(IntegerInfo),
+    InterfaceMethodInfo(InterfaceMethodRefInfo),
+    InvokeDynamicInfo(InvokeDynamicInfo),
+    LongInfo(LongInfo),
+    MethodHandleInfo(MethodHandleInfo),
+    MethodRefInfo(MethodRefInfo),
+    MethodTypeInfo(MethodTypeInfo),
+    NameAndTypeInfo(NameAndTypeInfo),
+    StringInfo(StringInfo),
+    Utf8Info(Utf8Info)
+}

--- a/src/constants/constant_factory.rs
+++ b/src/constants/constant_factory.rs
@@ -1,4 +1,5 @@
-use crate::constants::constant_info::{ConstantInfo};
+use crate::constants::constant_info::{ConstantInfo, UTF8, INTEGER, FLOAT, DOUBLE, LONG, CLASS,
+    STRING, FIELD_REF, METHOD_REF, INTERFACE_METHOD_REF, NAME_AND_TYPE, METHOD_HANDLE, METHOD_TYPE, INVOKE_DYNAMIC};
 use crate::constants::utf8_info::Utf8Info;
 use crate::constants::integer_info::IntegerInfo;
 use crate::constants::float_info::FloatInfo;
@@ -14,26 +15,27 @@ use crate::constants::method_handle_info::MethodHandleInfo;
 use crate::constants::method_type_info::MethodTypeInfo;
 use crate::constants::invoke_dynamic_info::InvokeDynamicInfo;
 use crate::read_bytes::ReadBytes;
+use crate::constants::constant_container::ConstantContainer;
 
-pub fn get_constant<T: ReadBytes>(mut data: &mut T) -> Box<dyn ConstantInfo>
+pub fn get_constant_container<T: ReadBytes>(mut data: &mut T) -> ConstantContainer
 {
     let tag_value: u8 = data.peek_u8();
     match tag_value
     {
-        UTF8    =>   { Box::new(Utf8Info::new(data)) },
-        INTEGER => { Box::new(IntegerInfo::new(data)) },
-        FLOAT   => { Box::new(FloatInfo::new(data)) },
-        LONG    => { Box::new(LongInfo::new(data)) },
-        DOUBLE  => { Box::new(DoubleInfo::new(data)) },
-        CLASS   => { Box::new(ClassInfo::new(data)) },
-        STRING  => { Box::new(StringInfo::new(data)) },
-        FIELD_REF   => { Box::new(FieldRefInfo::new(data)) },
-        METHOD_REF  => { Box::new(MethodRefInfo::new(data)) },
-        INTERFACE_METHOD_REF=> { Box::new(InterfaceMethodRefInfo::new(data)) },
-        NAME_AND_TYPE       => { Box::new(NameAndTypeInfo::new(data)) },
-        METHOD_HANDLE       => { Box::new(MethodHandleInfo::new(data)) },
-        METHOD_TYPE         => { Box::new(MethodTypeInfo::new(data)) },
-        INVOKE_DYNAMIC      => { Box::new(InvokeDynamicInfo::new(data)) }
-        _ => { panic!("Unidentified attribute") }
+        UTF8    => { ConstantContainer::Utf8Info(Utf8Info::new(data)) },
+        INTEGER => { ConstantContainer::IntegerInfo(IntegerInfo::new(data)) },
+        FLOAT   => { ConstantContainer::FloatInfo(FloatInfo::new(data)) },
+        LONG    => { ConstantContainer::LongInfo(LongInfo::new(data)) },
+        DOUBLE  => { ConstantContainer::DoubleInfo(DoubleInfo::new(data)) },
+        CLASS   => { ConstantContainer::ClassInfo(ClassInfo::new(data)) },
+        STRING  => { ConstantContainer::StringInfo(StringInfo::new(data)) },
+        FIELD_REF   => { ConstantContainer::FieldRefInfo(FieldRefInfo::new(data)) },
+        METHOD_REF  => { ConstantContainer::MethodRefInfo(MethodRefInfo::new(data)) },
+        INTERFACE_METHOD_REF=> { ConstantContainer::InterfaceMethodInfo((InterfaceMethodRefInfo::new(data))) },
+        NAME_AND_TYPE       => { ConstantContainer::NameAndTypeInfo(NameAndTypeInfo::new(data)) },
+        METHOD_HANDLE       => { ConstantContainer::MethodHandleInfo(MethodHandleInfo::new(data)) },
+        METHOD_TYPE         => { ConstantContainer::MethodTypeInfo(MethodTypeInfo::new(data)) },
+        INVOKE_DYNAMIC      => { ConstantContainer::InvokeDynamicInfo(InvokeDynamicInfo::new(data)) }
+        _ => { panic!("Unidentified constant info.") }
     }
 }

--- a/src/constants/constant_factory.rs
+++ b/src/constants/constant_factory.rs
@@ -36,6 +36,6 @@ pub fn get_constant_container<T: ReadBytes>(mut data: &mut T) -> ConstantContain
         METHOD_HANDLE       => { ConstantContainer::MethodHandleInfo(MethodHandleInfo::new(data)) },
         METHOD_TYPE         => { ConstantContainer::MethodTypeInfo(MethodTypeInfo::new(data)) },
         INVOKE_DYNAMIC      => { ConstantContainer::InvokeDynamicInfo(InvokeDynamicInfo::new(data)) }
-        _ => { panic!("Unidentified constant info.") }
+        _ => { panic!("Unidentified constant info: {}.", tag_value) }
     }
 }

--- a/src/constants/constant_info.rs
+++ b/src/constants/constant_info.rs
@@ -1,9 +1,6 @@
-use std::any::Any;
-
 pub trait ConstantInfo
 {
     fn tag(&self) -> &u8;
-    fn as_any(&self) -> &dyn Any;
 }
 
 

--- a/src/constants/double_info.rs
+++ b/src/constants/double_info.rs
@@ -1,6 +1,5 @@
 use crate::constants::constant_info::ConstantInfo;
 use crate::read_bytes::ReadBytes;
-use std::any::Any;
 
 #[derive(Default, PartialEq, Serialize, Deserialize, Debug, Clone)]
 pub struct DoubleInfo
@@ -12,8 +11,9 @@ pub struct DoubleInfo
 impl ConstantInfo for DoubleInfo
 {
     fn tag(&self) -> &u8 { &self.tag }
-    fn as_any(&self) -> &dyn Any { self }
 }
+
+impl Eq for DoubleInfo { }
 
 impl DoubleInfo
 {

--- a/src/constants/double_info.rs
+++ b/src/constants/double_info.rs
@@ -60,20 +60,19 @@ mod tests
     #[test]
     fn double_info_constructs_expected_struct()
     {
-        let mut data: VecDeque<u8> = vecdeque![1, 1, 1, 1, 1, 1, 1, 1, 1];
+        let mut data: VecDeque<u8> = get_default_vec();
         let result: DoubleInfo = DoubleInfo::new(&mut data);
 
         let bit8: u8 = 1;
         let bit16: u16 = 257;
         assert_eq!(bit8, result.tag);
-        // todo! this needs to be fixed.
-        // assert_eq!(bit16, result.value);
+        assert_eq!(123.125, result.value);
     }
 
     #[test]
     fn double_info_implements_equality_correctly()
     {
-        let mut data: VecDeque<u8> = vecdeque![1, 2, 3, 4, 5, 6, 7, 8, 9];
+        let mut data: VecDeque<u8> = get_default_vec();
         let mut data2: VecDeque<u8> = data.clone();
         let instance1: DoubleInfo = DoubleInfo::new(&mut data);
         let instance2: DoubleInfo = DoubleInfo::new(&mut data2);
@@ -84,8 +83,9 @@ mod tests
     #[test]
     fn double_info_implements_equality_correctly_when_not_equal()
     {
-        let mut data1: VecDeque<u8> = vecdeque![1, 2, 3, 4, 5, 6, 7, 8, 9];
-        let mut data2: VecDeque<u8> = vecdeque![9, 8, 7, 6, 5, 4, 3, 2, 1];
+        let mut data1: VecDeque<u8> = get_default_vec();
+        let mut data2: VecDeque<u8> = data1.clone();
+        data2[0] = data1[0] + 1;
         let instance1: DoubleInfo = DoubleInfo::new(&mut data1);
         let instance2: DoubleInfo = DoubleInfo::new(&mut data2);
 
@@ -95,7 +95,7 @@ mod tests
     #[test]
     fn double_info_implements_json_serialization_correctly() -> Result<()>
     {
-        let mut data: VecDeque<u8> = vecdeque![1, 2, 3, 4, 5, 6, 7, 8, 9];
+        let mut data: VecDeque<u8> = get_default_vec();
         let instance1: DoubleInfo = DoubleInfo::new(&mut data);
         let instance2 = instance1.clone();
 
@@ -104,5 +104,10 @@ mod tests
 
         assert_eq!(instance2, instance3);
         Ok(())
+    }
+
+    fn get_default_vec() -> VecDeque<u8>
+    {
+        vecdeque![1, 64, 94, 200, 0, 0, 0, 0, 0] // tag: 1 value: 123.125
     }
 }

--- a/src/constants/field_ref_info.rs
+++ b/src/constants/field_ref_info.rs
@@ -1,6 +1,5 @@
 use crate::constants::constant_info::ConstantInfo;
 use crate::read_bytes::ReadBytes;
-use std::any::Any;
 
 #[derive(Default, PartialEq, Eq, Serialize, Deserialize, Debug, Clone)]
 pub struct FieldRefInfo
@@ -13,7 +12,6 @@ pub struct FieldRefInfo
 impl ConstantInfo for FieldRefInfo
 {
     fn tag(&self) -> &u8 { &self.tag }
-    fn as_any(&self) -> &dyn Any { self }
 }
 
 impl FieldRefInfo

--- a/src/constants/float_info.rs
+++ b/src/constants/float_info.rs
@@ -32,74 +32,80 @@ impl FloatInfo
     fn unsigned_to_float(bits: &u32) -> f32
     {
         let s: f32 = if bits & 0x80000000 == 0 { 1. } else { -1. };
-        let e: u32 = (bits >> 23) & 0xff;
+        let e: i32 = ((bits >> 23) & 0x000000ff) as i32; // & gets rid of leading sign bit
         let m = if e == 0 { (bits & 0x7fffff) << 1 } else { (bits & 0x7fffff) | 0x800000 };
         let base: f32 = 2.0;
         s * m as f32 * base.powf((e - 150) as f32)
     }
 }
 
-// Figure out what each bit means in the float and then revisit.
-// #[cfg(test)]
-// mod tests
-// {
-//     use serde_json::Result;
-//     use crate::constants::float_info::FloatInfo;
-//
-//     #[test]
-//     fn float_info_implements_equality_by_default()
-//     {
-//         let instance1: FloatInfo = Default::default();
-//         let instance2: FloatInfo = Default::default();
-//
-//         assert_eq!(instance1, instance2);
-//     }
-//
-//     #[test]
-//     fn float_info_constructs_expected_struct()
-//     {
-//         let data: Vec<u8> = vec![1, 0, 0, 0, 1];
-//         let result: FloatInfo = FloatInfo::new(&data);
-//
-//         let bit8: u8 = 1;
-//         let bit16: u16 = 257;
-//         assert_eq!(bit8, result.tag);
-//         // todo! make sure this is implemented correctly.
-//         //assert_eq!(bit16, result.name_index);
-//     }
-//
-//     #[test]
-//     fn float_info_implements_equality_correctly()
-//     {
-//         let data: Vec<u8> = vec![1, 0, 0, 0, 1];
-//         let instance1: FloatInfo = FloatInfo::new(&data);
-//         let instance2: FloatInfo = FloatInfo::new(&data);
-//
-//         assert_eq!(instance1, instance2);
-//     }
-//
-//     #[test]
-//     fn float_info_implements_equality_correctly_when_not_equal()
-//     {
-//         let data1: Vec<u8> = vec![1, 0, 0, 0, 1];
-//         let data2: Vec<u8> = vec![1, 0, 0, 1, 0];
-//         let instance1: FloatInfo = FloatInfo::new(&data1);
-//         let instance2: FloatInfo = FloatInfo::new(&data2);
-//
-//         assert_ne!(instance1, instance2);
-//     }
-//
-//     #[test]
-//     fn float_info_implements_json_serialization_correctly() -> Result<()>
-//     {
-//         let data: Vec<u8> = vec![1, 0, 0, 0, 1];
-//         let instance1: FloatInfo = FloatInfo::new(&data);
-//         let instance2 = instance1.clone();
-//
-//         let json = serde_json::to_string_pretty(&instance1)?;
-//         let instance3: FloatInfo = serde_json::from_str(&json)?;
-//
-//         assert_eq!(instance2, instance3);
-//         Ok(())
-//     }
-// }
+#[cfg(test)]
+mod tests
+{
+    use serde_json::Result;
+    use crate::constants::float_info::FloatInfo;
+    use std::collections::VecDeque;
+    use crate::vecdeque;
+
+    #[test]
+    fn float_info_implements_equality_by_default()
+    {
+        let instance1: FloatInfo = Default::default();
+        let instance2: FloatInfo = Default::default();
+
+        assert_eq!(instance1, instance2);
+    }
+
+    #[test]
+    fn float_info_constructs_expected_struct()
+    {
+        let mut data: VecDeque<u8> = get_default_veq();
+        let result: FloatInfo = FloatInfo::new(&mut data);
+
+        let bit8: u8 = 1;
+        assert_eq!(bit8, result.tag);
+        assert_eq!(123.45, result.value);
+    }
+
+    #[test]
+    fn float_info_implements_equality_correctly()
+    {
+        let mut data: VecDeque<u8> = get_default_veq();
+        let mut data2: VecDeque<u8> = data.clone();
+        let instance1: FloatInfo = FloatInfo::new(&mut data);
+        let instance2: FloatInfo = FloatInfo::new(&mut data2);
+
+        assert_eq!(instance1, instance2);
+    }
+
+    #[test]
+    fn float_info_implements_equality_correctly_when_not_equal()
+    {
+        let mut data1: VecDeque<u8> = get_default_veq();
+        let mut data2: VecDeque<u8> = data1.clone();
+        data2[0] = data1[0] + 1;
+        let instance1: FloatInfo = FloatInfo::new(&mut data1);
+        let instance2: FloatInfo = FloatInfo::new(&mut data2);
+
+        assert_ne!(instance1, instance2);
+    }
+
+    #[test]
+    fn float_info_implements_json_serialization_correctly() -> Result<()>
+    {
+        let mut data: VecDeque<u8> = get_default_veq();
+        let instance1: FloatInfo = FloatInfo::new(&mut data);
+        let instance2 = instance1.clone();
+
+        let json = serde_json::to_string_pretty(&instance1)?;
+        let instance3: FloatInfo = serde_json::from_str(&json)?;
+
+        assert_eq!(instance2, instance3);
+        Ok(())
+    }
+
+    fn get_default_veq() -> VecDeque<u8>
+    {
+        vecdeque![1, 66, 246, 230, 102] // 123.45
+    }
+}

--- a/src/constants/float_info.rs
+++ b/src/constants/float_info.rs
@@ -1,6 +1,5 @@
 use crate::constants::constant_info::ConstantInfo;
 use crate::read_bytes::ReadBytes;
-use std::any::Any;
 
 #[derive(Default, PartialEq, Serialize, Deserialize, Debug, Clone)]
 pub struct FloatInfo
@@ -12,8 +11,9 @@ pub struct FloatInfo
 impl ConstantInfo for FloatInfo
 {
     fn tag(&self) -> &u8 { &self.tag }
-    fn as_any(&self) -> &dyn Any { self }
 }
+
+impl Eq for FloatInfo { }
 
 impl FloatInfo
 {

--- a/src/constants/integer_info.rs
+++ b/src/constants/integer_info.rs
@@ -1,7 +1,6 @@
 use crate::constants::constant_info::ConstantInfo;
 use crate::read_bytes::ReadBytes;
 use crate::attributes::attribute_info::AttributeInfo;
-use std::any::Any;
 
 #[derive(Default, PartialEq, Eq, Serialize, Deserialize, Debug, Clone)]
 pub struct IntegerInfo
@@ -13,7 +12,6 @@ pub struct IntegerInfo
 impl ConstantInfo for IntegerInfo
 {
     fn tag(&self) -> &u8 { &self.tag }
-    fn as_any(&self) -> &dyn Any { self }
 }
 
 impl IntegerInfo

--- a/src/constants/interface_method_ref_info.rs
+++ b/src/constants/interface_method_ref_info.rs
@@ -1,6 +1,5 @@
 use crate::constants::constant_info::ConstantInfo;
 use crate::read_bytes::ReadBytes;
-use std::any::Any;
 
 #[derive(Default, PartialEq, Eq, Serialize, Deserialize, Debug, Clone)]
 pub struct InterfaceMethodRefInfo
@@ -13,7 +12,6 @@ pub struct InterfaceMethodRefInfo
 impl ConstantInfo for InterfaceMethodRefInfo
 {
     fn tag(&self) -> &u8 { &self.tag }
-    fn as_any(&self) -> &dyn Any { self }
 }
 
 impl InterfaceMethodRefInfo

--- a/src/constants/invoke_dynamic_info.rs
+++ b/src/constants/invoke_dynamic_info.rs
@@ -1,6 +1,5 @@
 use crate::constants::constant_info::ConstantInfo;
 use crate::read_bytes::ReadBytes;
-use std::any::Any;
 
 #[derive(Default, PartialEq, Eq, Serialize, Deserialize, Debug, Clone)]
 pub struct InvokeDynamicInfo
@@ -13,7 +12,6 @@ pub struct InvokeDynamicInfo
 impl ConstantInfo for InvokeDynamicInfo
 {
     fn tag(&self) -> &u8 { &self.tag }
-    fn as_any(&self) -> &dyn Any { self }
 }
 
 impl InvokeDynamicInfo

--- a/src/constants/long_info.rs
+++ b/src/constants/long_info.rs
@@ -1,6 +1,5 @@
 use crate::constants::constant_info::ConstantInfo;
 use crate::read_bytes::ReadBytes;
-use std::any::Any;
 
 #[derive(Default, PartialEq, Eq, Serialize, Deserialize, Debug, Clone)]
 pub struct LongInfo
@@ -12,7 +11,6 @@ pub struct LongInfo
 impl ConstantInfo for LongInfo
 {
     fn tag(&self) -> &u8 { &self.tag }
-    fn as_any(&self) -> &dyn Any { self }
 }
 
 impl LongInfo

--- a/src/constants/method_handle_info.rs
+++ b/src/constants/method_handle_info.rs
@@ -1,7 +1,6 @@
 use crate::constants::constant_info::ConstantInfo;
 use crate::read_bytes::ReadBytes;
 use std::collections::VecDeque;
-use std::any::Any;
 
 #[derive(Default, PartialEq, Eq, Serialize, Deserialize, Debug, Clone)]
 pub struct MethodHandleInfo
@@ -14,7 +13,6 @@ pub struct MethodHandleInfo
 impl ConstantInfo for MethodHandleInfo
 {
     fn tag(&self) -> &u8 { &self.tag }
-    fn as_any(&self) -> &dyn Any { self }
 }
 
 impl MethodHandleInfo

--- a/src/constants/method_ref_info.rs
+++ b/src/constants/method_ref_info.rs
@@ -1,6 +1,5 @@
 use crate::constants::constant_info::ConstantInfo;
 use crate::read_bytes::ReadBytes;
-use std::any::Any;
 
 #[derive(Default, PartialEq, Eq, Serialize, Deserialize, Debug, Clone)]
 pub struct MethodRefInfo
@@ -13,7 +12,6 @@ pub struct MethodRefInfo
 impl ConstantInfo for MethodRefInfo
 {
     fn tag(&self) -> &u8 { &self.tag }
-    fn as_any(&self) -> &dyn Any { self }
 }
 
 impl MethodRefInfo

--- a/src/constants/method_type_info.rs
+++ b/src/constants/method_type_info.rs
@@ -1,6 +1,5 @@
 use crate::constants::constant_info::ConstantInfo;
 use crate::read_bytes::ReadBytes;
-use std::any::Any;
 
 #[derive(Default, PartialEq, Eq, Serialize, Deserialize, Debug, Clone)]
 pub struct MethodTypeInfo
@@ -12,7 +11,6 @@ pub struct MethodTypeInfo
 impl ConstantInfo for MethodTypeInfo
 {
     fn tag(&self) -> &u8 { &self.tag }
-    fn as_any(&self) -> &dyn Any { self }
 }
 
 impl MethodTypeInfo

--- a/src/constants/name_and_type_info.rs
+++ b/src/constants/name_and_type_info.rs
@@ -1,6 +1,5 @@
 use crate::constants::constant_info::ConstantInfo;
 use crate::read_bytes::ReadBytes;
-use std::any::Any;
 
 #[derive(Default, PartialEq, Eq, Serialize, Deserialize, Debug, Clone)]
 pub struct NameAndTypeInfo
@@ -13,7 +12,6 @@ pub struct NameAndTypeInfo
 impl ConstantInfo for NameAndTypeInfo
 {
     fn tag(&self) -> &u8 { &self.tag }
-    fn as_any(&self) -> &dyn Any { self }
 }
 
 impl NameAndTypeInfo

--- a/src/constants/string_info.rs
+++ b/src/constants/string_info.rs
@@ -1,6 +1,5 @@
 use crate::constants::constant_info::ConstantInfo;
 use crate::read_bytes::ReadBytes;
-use std::any::Any;
 
 #[derive(Default, PartialEq, Eq, Serialize, Deserialize, Debug, Clone)]
 pub struct StringInfo
@@ -12,7 +11,6 @@ pub struct StringInfo
 impl ConstantInfo for StringInfo
 {
     fn tag(&self) -> &u8 { &self.tag }
-    fn as_any(&self) -> &dyn Any { self }
 }
 
 impl StringInfo

--- a/src/constants/utf8_info.rs
+++ b/src/constants/utf8_info.rs
@@ -1,5 +1,6 @@
 use crate::constants::constant_info::ConstantInfo;
 use crate::read_bytes::ReadBytes;
+use std::str::from_utf8;
 
 #[derive(Default, PartialEq, Eq, Serialize, Deserialize, Debug, Clone)]
 pub struct Utf8Info
@@ -32,7 +33,11 @@ impl Utf8Info
 
     pub fn get_string(&self) -> &str
     {
-        "hello"
+        match std::str::from_utf8(&self.value)
+        {
+            Ok(v) => v,
+            Err(e) => panic!("Could not parse UTF8 value")
+        }
     }
 }
 
@@ -101,5 +106,16 @@ mod tests
 
         assert_eq!(instance2, instance3);
         Ok(())
+    }
+
+    #[test]
+    fn utf8_info_implements_get_string_correctly()
+    {
+        let mut data: VecDeque<u8> = vecdeque![1, 0, 3, 'c' as u8, 'a' as u8, 't' as u8];
+        let result: Utf8Info = Utf8Info::new(&mut data);
+
+        assert_eq!(1, result.tag);
+        assert_eq!(3, result.length);
+        assert_eq!("cat", result.get_string());
     }
 }

--- a/src/constants/utf8_info.rs
+++ b/src/constants/utf8_info.rs
@@ -1,6 +1,5 @@
 use crate::constants::constant_info::ConstantInfo;
 use crate::read_bytes::ReadBytes;
-use std::any::Any;
 
 #[derive(Default, PartialEq, Eq, Serialize, Deserialize, Debug, Clone)]
 pub struct Utf8Info
@@ -15,7 +14,6 @@ pub struct Utf8Info
 impl ConstantInfo for Utf8Info
 {
     fn tag(&self) -> &u8 { &self.tag }
-    fn as_any(&self) -> &dyn Any { self }
 }
 
 impl Utf8Info

--- a/src/field_info.rs
+++ b/src/field_info.rs
@@ -9,23 +9,10 @@ use crate::constants::constant_container::ConstantContainer;
 #[derive(Default, PartialEq, Eq, Serialize, Deserialize, Debug, Clone)]
 pub struct FieldInfo
 {
-    /// Mask of flags used to denote access permissions to
-    /// and properties of ths filed.
     access_flags: u16,
-
-    /// Valid index into the constant_pool table. The entry at the
-    /// index must be a CONSTANT_Utf8_info struct.
     name_index: u16,
-
-    /// Valid index into the constant_pool table. The entry at the
-    /// index must be a CONSTANT_Utf8_info struct.
     descriptor_index: u16,
-
-    /// Number of additional attributes of this field.
     attributes_count: u16,
-
-    /// Each value of the attributes table must be an
-    /// attribute structure. Can have any number of attributes.
     attributes: Vec<AttributeContainer>
 }
 
@@ -47,18 +34,4 @@ impl FieldInfo
 
         result
     }
-}
-
-#[warn(dead_code)]
-pub enum FieldAccessFlags
-{
-    Public = 0x0001,
-    Private = 0x0002,
-    Protected = 0x0004,
-    Static = 0x0008,
-    Final = 0x0010,
-    Volatile = 0x0040,
-    Transient = 0x0080,
-    Synthetic = 0x1000,
-    Enum = 0x4000
 }

--- a/src/field_info.rs
+++ b/src/field_info.rs
@@ -1,10 +1,12 @@
 use crate::attributes::attribute_info::AttributeInfo;
 use crate::constants::constant_info::ConstantInfo;
 use crate::read_bytes::ReadBytes;
-use crate::attributes::attribute_factory::get_attribute;
+use crate::attributes::attribute_factory::{get_attribute_container};
 use serde_json::de::Read;
+use crate::attributes::attribute_container::AttributeContainer;
+use crate::constants::constant_container::ConstantContainer;
 
-#[derive(Default)]
+#[derive(Default, PartialEq, Eq, Serialize, Deserialize, Debug, Clone)]
 pub struct FieldInfo
 {
     /// Mask of flags used to denote access permissions to
@@ -24,14 +26,12 @@ pub struct FieldInfo
 
     /// Each value of the attributes table must be an
     /// attribute structure. Can have any number of attributes.
-    // TODO: implement Clone, Debug, Serialize, Deserialize for this type
-    //      so other structs can derive it.
-    attributes: Vec<Box<dyn AttributeInfo>>
+    attributes: Vec<AttributeContainer>
 }
 
 impl FieldInfo
 {
-    pub fn new<T: ReadBytes>(mut data: &mut T, constant_pool: &[Box<dyn ConstantInfo>]) -> FieldInfo
+    pub fn new<T: ReadBytes>(mut data: &mut T, constant_pool: &[ConstantContainer]) -> FieldInfo
     {
         let mut result: FieldInfo = Default::default();
         result.access_flags = data.pop_u16();
@@ -42,7 +42,7 @@ impl FieldInfo
         result.attributes = Vec::new();
         for _i in 0..result.attributes_count.clone()
         {
-            result.attributes.push(get_attribute(data, &constant_pool));
+            result.attributes.push(get_attribute_container(data, &constant_pool));
         }
 
         result

--- a/src/field_info.rs
+++ b/src/field_info.rs
@@ -35,3 +35,113 @@ impl FieldInfo
         result
     }
 }
+
+#[cfg(test)]
+mod tests
+{
+    use serde_json::Result;
+    use crate::vecdeque;
+    use std::collections::VecDeque;
+    use crate::field_info::FieldInfo;
+    use crate::constants::constant_container::ConstantContainer;
+    use crate::constants::utf8_info::Utf8Info;
+    use crate::attributes::constant_value_attribute::ConstantValueAttribute;
+    use crate::attributes::attribute_container::AttributeContainer;
+
+    #[test]
+    fn field_info_implements_equality_by_default()
+    {
+        let instance1: FieldInfo = Default::default();
+        let instance2: FieldInfo = Default::default();
+
+        assert_eq!(instance1, instance2);
+    }
+
+    #[test]
+    fn field_info_constructs_expected_struct()
+    {
+        let mut data: VecDeque<u8> = get_default_vec();
+        let constant_pool = get_default_cp();
+        let result: FieldInfo = FieldInfo::new(&mut data, &constant_pool);
+
+        assert_eq!(1, result.access_flags);
+        assert_eq!(123, result.name_index);
+        assert_eq!(5, result.descriptor_index);
+        assert_eq!(1, result.attributes_count);
+
+        assert_eq!(1, result.attributes.len());
+
+        let mut content_vec: VecDeque<u8> = vecdeque![0, 0, 1, 1, 1, 1, 0, 2];
+        let expected_attribute: AttributeContainer =
+            AttributeContainer::ConstantAttribute(ConstantValueAttribute::new(&mut content_vec));
+        assert_eq!(expected_attribute, result.attributes[0]);
+    }
+
+    #[test]
+    fn field_info_implements_equality_correctly()
+    {
+        let mut data: VecDeque<u8> = get_default_vec();
+        let mut data2: VecDeque<u8> = data.clone();
+        let constant_pool = get_default_cp();
+        let instance1: FieldInfo = FieldInfo::new(&mut data, &constant_pool);
+        let instance2: FieldInfo = FieldInfo::new(&mut data2, &constant_pool);
+
+        assert_eq!(instance1, instance2);
+    }
+
+    #[test]
+    fn field_info_implements_equality_correctly_when_not_equal()
+    {
+        let mut data: VecDeque<u8> = get_default_vec();
+        let mut data2: VecDeque<u8> = data.clone();
+        data2[0] = data[0] + 1;
+        let constant_pool = get_default_cp();
+        let instance1: FieldInfo = FieldInfo::new(&mut data, &constant_pool);
+        let instance2: FieldInfo = FieldInfo::new(&mut data2, &constant_pool);
+
+        assert_ne!(instance1, instance2);
+    }
+
+    #[test]
+    fn field_info_implements_json_serialization_correctly() -> Result<()>
+    {
+        let mut data: VecDeque<u8> = get_default_vec();
+        let constant_pool = get_default_cp();
+
+        let instance1: FieldInfo = FieldInfo::new(&mut data, &constant_pool);
+        let instance2 = instance1.clone();
+
+        let json = serde_json::to_string_pretty(&instance1)?;
+        let instance3: FieldInfo = serde_json::from_str(&json)?;
+
+        assert_eq!(instance2, instance3);
+        Ok(())
+    }
+
+    fn get_default_vec() -> VecDeque<u8>
+    {
+        vecdeque![
+            0, 1,       // access_flags
+            0, 123,     // name_index
+            0, 5,       // descriptor_index
+            0, 1,       // attributes_count
+            0, 0,       // ConstantValueAttribute::attribute_name_index
+            1, 1, 1, 1, // ConstantValueAttribute::attribute_length
+            0, 2        // ConstantValueAttribute::constant_value_index
+        ]
+    }
+
+    fn get_default_cp() -> Vec<ConstantContainer>
+    {
+        let attr_name: &str = "ConstantValue";
+        let mut attr_contents = vecdeque![
+            0,       // tag
+            0, 13,   // length
+        ];
+        attr_contents.extend(attr_name.as_bytes().iter().copied());
+
+        vec![
+            ConstantContainer::Utf8Info(Utf8Info::new(&mut attr_contents))
+        ]
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,6 @@ extern crate serde;
 extern crate serde_json;
 #[macro_use] extern crate serde_derive;
 
-
 #[cfg(test)]
 mod tests {
     #[test]

--- a/src/method_info.rs
+++ b/src/method_info.rs
@@ -34,3 +34,113 @@ impl MethodInfo
         result
     }
 }
+
+#[cfg(test)]
+mod tests
+{
+    use serde_json::Result;
+    use crate::vecdeque;
+    use std::collections::VecDeque;
+    use crate::method_info::MethodInfo;
+    use crate::constants::constant_container::ConstantContainer;
+    use crate::constants::utf8_info::Utf8Info;
+    use crate::attributes::constant_value_attribute::ConstantValueAttribute;
+    use crate::attributes::attribute_container::AttributeContainer;
+
+    #[test]
+    fn method_info_implements_equality_by_default()
+    {
+        let instance1: MethodInfo = Default::default();
+        let instance2: MethodInfo = Default::default();
+
+        assert_eq!(instance1, instance2);
+    }
+
+    #[test]
+    fn method_info_constructs_expected_struct()
+    {
+        let mut data: VecDeque<u8> = get_default_vec();
+        let constant_pool = get_default_cp();
+        let result: MethodInfo = MethodInfo::new(&mut data, &constant_pool);
+
+        assert_eq!(1, result.access_flags);
+        assert_eq!(123, result.name_index);
+        assert_eq!(5, result.descriptor_index);
+        assert_eq!(1, result.attributes_count);
+
+        assert_eq!(1, result.attributes.len());
+
+        let mut content_vec: VecDeque<u8> = vecdeque![0, 0, 1, 1, 1, 1, 0, 2];
+        let expected_attribute: AttributeContainer =
+            AttributeContainer::ConstantAttribute(ConstantValueAttribute::new(&mut content_vec));
+        assert_eq!(expected_attribute, result.attributes[0]);
+    }
+
+    #[test]
+    fn method_info_implements_equality_correctly()
+    {
+        let mut data: VecDeque<u8> = get_default_vec();
+        let mut data2: VecDeque<u8> = data.clone();
+        let constant_pool = get_default_cp();
+        let instance1: MethodInfo = MethodInfo::new(&mut data, &constant_pool);
+        let instance2: MethodInfo = MethodInfo::new(&mut data2, &constant_pool);
+
+        assert_eq!(instance1, instance2);
+    }
+
+    #[test]
+    fn method_info_implements_equality_correctly_when_not_equal()
+    {
+        let mut data: VecDeque<u8> = get_default_vec();
+        let mut data2: VecDeque<u8> = data.clone();
+        data2[0] = data[0] + 1;
+        let constant_pool = get_default_cp();
+        let instance1: MethodInfo = MethodInfo::new(&mut data, &constant_pool);
+        let instance2: MethodInfo = MethodInfo::new(&mut data2, &constant_pool);
+
+        assert_ne!(instance1, instance2);
+    }
+
+    #[test]
+    fn method_info_implements_json_serialization_correctly() -> Result<()>
+    {
+        let mut data: VecDeque<u8> = get_default_vec();
+        let constant_pool = get_default_cp();
+
+        let instance1: MethodInfo = MethodInfo::new(&mut data, &constant_pool);
+        let instance2 = instance1.clone();
+
+        let json = serde_json::to_string_pretty(&instance1)?;
+        let instance3: MethodInfo = serde_json::from_str(&json)?;
+
+        assert_eq!(instance2, instance3);
+        Ok(())
+    }
+
+    fn get_default_vec() -> VecDeque<u8>
+    {
+        vecdeque![
+            0, 1,       // access_flags
+            0, 123,     // name_index
+            0, 5,       // descriptor_index
+            0, 1,       // attributes_count
+            0, 0,       // ConstantValueAttribute::attribute_name_index
+            1, 1, 1, 1, // ConstantValueAttribute::attribute_length
+            0, 2        // ConstantValueAttribute::constant_value_index
+        ]
+    }
+
+    fn get_default_cp() -> Vec<ConstantContainer>
+    {
+        let attr_name: &str = "ConstantValue";
+        let mut attr_contents = vecdeque![
+            0,       // tag
+            0, 13,   // length
+        ];
+        attr_contents.extend(attr_name.as_bytes().iter().copied());
+
+        vec![
+            ConstantContainer::Utf8Info(Utf8Info::new(&mut attr_contents))
+        ]
+    }
+}

--- a/src/method_info.rs
+++ b/src/method_info.rs
@@ -1,22 +1,23 @@
-use crate::attributes::attribute_info::AttributeInfo;
 use crate::constants::constant_info::ConstantInfo;
 use crate::read_bytes::ReadBytes;
-use crate::attributes::attribute_factory::get_attribute;
+use crate::attributes::attribute_factory::{get_attribute_container};
 use serde_json::de::Read;
+use crate::attributes::attribute_container::AttributeContainer;
+use crate::constants::constant_container::ConstantContainer;
 
-#[derive(Default)]
+#[derive(Default, PartialEq, Eq, Serialize, Deserialize, Debug, Clone)]
 pub struct MethodInfo
 {
     access_flags: u16,
     name_index: u16,
     descriptor_index: u16,
     attributes_count: u16,
-    attributes: Vec<Box<dyn AttributeInfo>>
+    attributes: Vec<AttributeContainer>
 }
 
 impl MethodInfo
 {
-    pub fn new<T: ReadBytes>(mut data: &mut T, constant_pool: &[Box<dyn ConstantInfo>]) -> MethodInfo
+    pub fn new<T: ReadBytes>(mut data: &mut T, constant_pool: &[ConstantContainer]) -> MethodInfo
     {
         let mut result: MethodInfo = Default::default();
         result.access_flags = data.pop_u16();
@@ -27,7 +28,7 @@ impl MethodInfo
         result.attributes = Vec::new();
         for _i in 0..result.attributes_count.clone()
         {
-            result.attributes.push(get_attribute(data, &constant_pool));
+            result.attributes.push(get_attribute_container(data, &constant_pool));
         }
 
         result


### PR DESCRIPTION
Instead of using dynamic dispatch, wrap similar structs in an enum.